### PR TITLE
fix(rdma): don't create device cq in cq-per-ep mode

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -214,6 +214,20 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  */
 OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", 8192);
 
+/*
+ * If 0, create a Libfabric endpoint per domain, shared across all
+ * communicators.  If non-0, create a Libfabric endpoint per
+ * communicator.
+ */
+OFI_NCCL_PARAM_INT(endpoint_per_communicator, "ENDPOINT_PER_COMM", 1);
+
+/*
+ * If 0, create a Libfabric CQ per domain, even if Libfabric endpoints
+ * are associated with communicators.  If non-zer, create a CQ per
+ * endpoint, regardless of how many endpoints are created per domain.
+ */
+OFI_NCCL_PARAM_INT(cq_per_endpoint, "CQ_PER_ENDPOINT", 0);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -577,9 +577,6 @@ struct nccl_net_ofi_rdma_ep {
 	 * and its base struct. */
 	nccl_net_ofi_ep_t base;
 
-	/* ID pool */
-	nccl_ofi_idpool_t *comm_idpool;
-
 	/* Number of rails */
 	int num_rails;
 
@@ -595,10 +592,6 @@ struct nccl_net_ofi_rdma_ep {
 	 * zero. rdma_release_ep() releases the resources if the
 	 * reference counter is decreased down to zero. */
 	int ref_cnt;
-
-	/* Array of open comms associated with this endpoint. This is needed for fast
-	   lookup of comms in the RDMA protocol. */
-	nccl_net_ofi_comm_t **comms;
 
 	/* Pending requests queue */
 	nccl_ofi_deque_t *pending_reqs_queue;
@@ -683,6 +676,13 @@ typedef struct nccl_net_ofi_rdma_device {
 
 	/* Maximum number of supported communicator IDs */
 	uint32_t num_comm_ids;
+
+	/* ID pool */
+	nccl_ofi_idpool_t *comm_idpool;
+
+	/* Array of open comms associated with this endpoint. This is needed for fast
+	   lookup of comms in the RDMA protocol. */
+	nccl_net_ofi_comm_t **comms;
 
 	/* Memory registration key pool */
 	nccl_ofi_idpool_t key_pool;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -619,6 +619,9 @@ typedef struct nccl_net_ofi_rdma_device_rail {
 
 	/* Access domain handles */
 	struct fid_domain *domain;
+
+	/* Completion Queue handle */
+	struct fid_cq *cq;
 } nccl_net_ofi_rdma_device_rail_t;
 
 /*

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -262,17 +262,19 @@ int nccl_ofi_ofiutils_init_connection(int api_version, struct fi_info *info, str
 		goto error;
 	}
 
-	if (info->caps & FI_TAGGED) {
-		cq_attr.format = FI_CQ_FORMAT_TAGGED;
-	} else {
-		cq_attr.format = FI_CQ_FORMAT_DATA;
-	}
+	if (*cq == NULL) {
+		if (info->caps & FI_TAGGED) {
+			cq_attr.format = FI_CQ_FORMAT_TAGGED;
+		} else {
+			cq_attr.format = FI_CQ_FORMAT_DATA;
+		}
 
-	ret = fi_cq_open(domain, &cq_attr, cq, NULL);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",
-			      ret, fi_strerror(-ret));
-		goto error;
+		ret = fi_cq_open(domain, &cq_attr, cq, NULL);
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",
+				      ret, fi_strerror(-ret));
+			goto error;
+		}
 	}
 
 	/* Open AV */

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -133,13 +133,22 @@ static inline int free_base_req(uint64_t *num_inflight_reqs,
 
 static inline int check_post_bounce_req(nccl_net_ofi_rdma_req_t *bounce_req);
 
+static inline nccl_net_ofi_rdma_device_t *get_device_from_ep(nccl_net_ofi_rdma_ep_t *ep)
+{
+	return (nccl_net_ofi_rdma_device_t*)ep->base.device;
+}
+
+
 /*
  * @brief	Get endpoint communicator with given ID
  */
 static inline nccl_net_ofi_comm_t *get_comm(nccl_net_ofi_rdma_ep_t *ep, uint32_t local_comm_id)
 {
+	nccl_net_ofi_rdma_device_t *device = get_device_from_ep(ep);
+
 	assert(local_comm_id < NCCL_OFI_RDMA_MAX_COMMS);
-	return ep->comms[local_comm_id];
+	assert(local_comm_id < device->num_comm_ids);
+	return device->comms[local_comm_id];
 }
 
 /*
@@ -149,8 +158,11 @@ static inline void set_comm(nccl_net_ofi_rdma_ep_t *ep,
 			    uint32_t local_comm_id,
 			    nccl_net_ofi_comm_t *comm)
 {
+	nccl_net_ofi_rdma_device_t *device = get_device_from_ep(ep);
+
 	assert(local_comm_id < NCCL_OFI_RDMA_MAX_COMMS);
-	ep->comms[local_comm_id] = comm;
+	assert(local_comm_id < device->num_comm_ids);
+	device->comms[local_comm_id] = comm;
 }
 
 /*
@@ -3255,7 +3267,7 @@ static int recv_close(nccl_net_ofi_recv_comm_t *recv_comm)
 	set_comm(ep, r_comm->local_comm_id, NULL);
 
 	/* Release communicator ID */
-	ret = nccl_ofi_idpool_free_id(ep->comm_idpool, r_comm->local_comm_id);
+	ret = nccl_ofi_idpool_free_id(device->comm_idpool, r_comm->local_comm_id);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", r_comm->local_comm_id);
 	}
@@ -3478,7 +3490,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device
 	r_comm->base.close = recv_close;
 
 	/* Allocate recv communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(ep->comm_idpool);
+	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		r_comm->local_comm_id = ~0;
 		goto error;
@@ -3490,7 +3502,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device
 		NCCL_OFI_WARN("Received an invalid communicator ID %lu for device %d", conn_msg->local_comm_id,
 					  dev_id);
 		goto error;
-    }
+	}
 
 	r_comm->remote_comm_id = conn_msg->local_comm_id;
 	r_comm->next_msg_seq_num = 0;
@@ -3588,7 +3600,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device
 		if (r_comm->msgbuff)
 			nccl_ofi_msgbuff_destroy(r_comm->msgbuff);
 		if (~0 != r_comm->local_comm_id) {
-			ret = nccl_ofi_idpool_free_id(ep->comm_idpool, r_comm->local_comm_id);
+			ret = nccl_ofi_idpool_free_id(device->comm_idpool, r_comm->local_comm_id);
 			if (ret != 0) {
 				NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", r_comm->local_comm_id);
 			}
@@ -3948,7 +3960,8 @@ static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
 	}
 
 	/* Release communicator ID */
-	ret = nccl_ofi_idpool_free_id(((nccl_net_ofi_rdma_ep_t *)base_ep)->comm_idpool, l_comm->comm_id);
+	ret = nccl_ofi_idpool_free_id(get_device_from_ep((nccl_net_ofi_rdma_ep_t *)base_ep)->comm_idpool,
+				      l_comm->comm_id);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", l_comm->comm_id);
 	}
@@ -3997,8 +4010,8 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	l_comm->base.close = listen_close;
 	l_comm->leader_local_ep = first_rail->ofi_ep;
 
-    /* Allocate listen communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(ep->comm_idpool);
+	/* Allocate listen communicator ID */
+	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		l_comm->comm_id = ~0;
 		ret = comm_id;
@@ -4021,8 +4034,8 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 
  error:
 	if (l_comm && ~0 != l_comm->comm_id) {
-		if (0 != nccl_ofi_idpool_free_id(ep->comm_idpool, l_comm->comm_id)) {
-			NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", l_comm->comm_id);
+		if (0 != nccl_ofi_idpool_free_id(device->comm_idpool, l_comm->comm_id)) {
+			NCCL_OFI_WARN("Error freeing communicator ID %"PRIu64"", l_comm->comm_id);
 		}
 	}
 	free(l_comm);
@@ -4690,7 +4703,8 @@ static int send_close(nccl_net_ofi_rdma_send_comm_t *s_comm)
 	set_comm(ep, s_comm->local_comm_id, NULL);
 
 	/* Release communicator ID */
-	ret = nccl_ofi_idpool_free_id(ep->comm_idpool, s_comm->local_comm_id);
+	nccl_net_ofi_rdma_device_t *device = get_device_from_ep(ep);
+	ret = nccl_ofi_idpool_free_id(device->comm_idpool, s_comm->local_comm_id);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", s_comm->local_comm_id);
 	}
@@ -4955,7 +4969,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->remote_comm_id = handle->comm_id;
 
 	/* Allocate send communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(ep->comm_idpool);
+	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		ret_s_comm->local_comm_id = ~0;
 		ret = comm_id;
@@ -5023,7 +5037,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 
  error:
 	if (ret_s_comm && ~0 != ret_s_comm->local_comm_id) {
-		if (0 != nccl_ofi_idpool_free_id(ep->comm_idpool, ret_s_comm->local_comm_id)) {
+		if (0 != nccl_ofi_idpool_free_id(device->comm_idpool, ret_s_comm->local_comm_id)) {
 			NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", ret_s_comm->local_comm_id);
 		}
 	}
@@ -5473,17 +5487,6 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 			goto unlock;
 		}
 
-		ret = nccl_ofi_idpool_fini(ep->comm_idpool);
-		if (OFI_UNLIKELY(ret != 0)) {
-			goto unlock;
-		}
-
-		free(ep->comm_idpool);
-		ep->comm_idpool = NULL;
-
-		free(ep->comms);
-		ep->comms = NULL;
-
 		ret = nccl_ofi_deque_finalize(ep->pending_reqs_queue);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to finalize pending_reqs_queue: %d", ret);
@@ -5570,30 +5573,6 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 		ret = nccl_ofi_deque_init(&ep->pending_reqs_queue);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to init pending_reqs_queue: %d", ret);
-			goto unlock;
-		}
-
-		/* Create array of comms. */
-		/* TODO make this array expandable */
-		ep->comms = calloc(NCCL_OFI_RDMA_MAX_COMMS, sizeof(nccl_net_ofi_comm_t*));
-		if (!ep->comms) {
-			NCCL_OFI_WARN("Failed to alloc comms array");
-			ret = -ENOMEM;
-			goto unlock;
-		}
-
-		/* Initialize endpoint ID pool */
-		ep->comm_idpool = malloc(sizeof(nccl_ofi_idpool_t));
-		if (OFI_UNLIKELY(ep->comm_idpool == NULL)) {
-			ret = -ENOMEM;
-			NCCL_OFI_WARN("Unable to allocate rdma endpoint ID pool");
-			goto unlock;
-		}
-
-		ret = nccl_ofi_idpool_init(ep->comm_idpool, device->num_comm_ids);
-		if (OFI_UNLIKELY(ret != 0)) {
-			free(ep->comm_idpool);
-			ep->comm_idpool = NULL;
 			goto unlock;
 		}
 
@@ -6036,6 +6015,30 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		/* Initialize libfabric resources of rdma device */
 		ret = device_prepare_for_connection(device);
 		if (ret != 0) {
+			goto error;
+		}
+
+		/* Create array of comms. */
+		/* TODO make this array expandable */
+		device->comms = calloc(NCCL_OFI_RDMA_MAX_COMMS, sizeof(nccl_net_ofi_comm_t*));
+		if (!device->comms) {
+			NCCL_OFI_WARN("Failed to alloc comms array");
+			ret = -ENOMEM;
+			goto error;
+		}
+
+		/* Initialize endpoint ID pool */
+		device->comm_idpool = malloc(sizeof(nccl_ofi_idpool_t));
+		if (OFI_UNLIKELY(device->comm_idpool == NULL)) {
+			NCCL_OFI_WARN("Unable to allocate rdma endpoint ID pool");
+			ret = -ENOMEM;
+			goto error;
+		}
+
+		ret = nccl_ofi_idpool_init(device->comm_idpool, device->num_comm_ids);
+		if (OFI_UNLIKELY(ret != 0)) {
+			free(device->comm_idpool);
+			device->comm_idpool = NULL;
 			goto error;
 		}
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5398,6 +5398,9 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 
 	ep_rail->cq = dev_rail->cq;
 
+	assert(ofi_nccl_cq_per_endpoint() == 0 ? dev_rail->cq != NULL :
+	       dev_rail->cq == NULL);
+
 	ret = nccl_ofi_ofiutils_init_connection(FI_VERSION(1, 18), dev_rail->info, dev_rail->domain, &ep_rail->ofi_ep,
 						&ep_rail->av, &ep_rail->cq);
 	if (ret != 0) {
@@ -5659,7 +5662,9 @@ static int init_device_rail_ofi_resources(nccl_net_ofi_rdma_device_rail_t *rail_
 		}
 	}
 
-	if (ofi_nccl_cq_per_endpoint() == 0) {
+	if (ofi_nccl_cq_per_endpoint() != 0) {
+		/* In this mode, set cq to NULL, so a cq will be created
+		   separately for each endpoint */
 		rail_dev->cq = NULL;
 	} else {
 		cq_attr.format = FI_CQ_FORMAT_DATA;


### PR DESCRIPTION
The logic was incorrectly creating a device cq in cq-per-ep mode, so
essentially the flag's behavior was flipped.

Also add an assertion for this.

**Note**: only the last commit here needs to be reviewed -- the rest is just a rebase on master.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
